### PR TITLE
optimize text in the outro

### DIFF
--- a/lib/demo/caching_builder.dart
+++ b/lib/demo/caching_builder.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+
+/// Builds a widget by calling [builder]. Rebuilds the widget when [cacheKey]
+/// changes.
+///
+/// Use this to prevent unnecessary rebuilds of expensive widgets by changing
+/// the [cacheKey] only when a rebuild is necessary. Typically, the cache key
+/// would consist of values used by [builder] to build the widget.
+class CachingBuilder<V> extends StatefulWidget {
+  CachingBuilder({
+    @required this.cacheKey,
+    @required this.builder,
+  });
+
+  final V cacheKey;
+  final WidgetBuilder builder;
+
+  @override
+  _CachingBuilderState<V> createState() => _CachingBuilderState<V>();
+}
+
+class _CachingBuilderState<V> extends State<CachingBuilder<V>> {
+  V _lastCacheKey;
+  Widget _cachedWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_cachedWidget != null && _lastCacheKey == widget.cacheKey) {
+      return _cachedWidget;
+    } else {
+      _cachedWidget = widget.builder(context);
+      _lastCacheKey = widget.cacheKey;
+      return _cachedWidget;
+    }
+  }
+}

--- a/lib/demo/outro/outro.dart
+++ b/lib/demo/outro/outro.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:simple_animations/simple_animations.dart';
 import 'package:supercharged/supercharged.dart';
 
+import '../caching_builder.dart';
 import '../intro/large_text.dart';
 
 class Outro extends StatelessWidget {
@@ -62,26 +63,33 @@ class Outro extends StatelessWidget {
       _buildText('created by', 'Felix Blaschke', fontSize),
       Opacity(
         opacity: value.get(_P.opacityOther),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildSpacer(fontSize),
-            _buildText(
-                'directed by', 'Felix Blaschke\nMandy Blaschke', fontSize),
-            _buildSpacer(fontSize),
-            _buildText('Artwork by', 'Mandy Blaschke', fontSize),
-            _buildSpacer(fontSize),
-            _buildText('Made with', 'Flutter SDK', fontSize),
-            _buildSpacer(fontSize),
-            _buildText('animation package used', 'simple_animations', fontSize),
-            _buildSpacer(fontSize),
-            _buildText('Special thanks to', 'The Flutter Team', fontSize),
-            Container(
-              height: fontSize * 0.2,
-            ),
-            LargeText('for creating this awesome technology.',
-                textSize: fontSize * 0.43),
-          ],
+        child: CachingBuilder<double>(
+          cacheKey: fontSize,
+          builder: (context) {
+            return RepaintBoundary(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildSpacer(fontSize),
+                  _buildText(
+                      'directed by', 'Felix Blaschke\nMandy Blaschke', fontSize),
+                  _buildSpacer(fontSize),
+                  _buildText('Artwork by', 'Mandy Blaschke', fontSize),
+                  _buildSpacer(fontSize),
+                  _buildText('Made with', 'Flutter SDK', fontSize),
+                  _buildSpacer(fontSize),
+                  _buildText('animation package used', 'simple_animations', fontSize),
+                  _buildSpacer(fontSize),
+                  _buildText('Special thanks to', 'The Flutter Team', fontSize),
+                  Container(
+                    height: fontSize * 0.2,
+                  ),
+                  LargeText('for creating this awesome technology.',
+                      textSize: fontSize * 0.43),
+                ],
+              ),
+            );
+          },
         ),
       )
     ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'routed_app.dart';
 void main() {
   setPathUrlStrategy();
 
-  if (kReleaseMode) {
+  if (kReleaseMode || kProfileMode) {
     runApp(RoutedApp());
   } else {
     runApp(DevApp());

--- a/lib/showroom/show_room.dart
+++ b/lib/showroom/show_room.dart
@@ -11,6 +11,7 @@ import '../demo/layout/layout_b.dart';
 import '../demo/layout/layout_c.dart';
 import '../demo/layout/layout_d.dart';
 import '../demo/layout/layout_wall.dart';
+import '../demo/outro/outro.dart';
 import '../demo/sky/dash.dart';
 import '../demo/sky/sky.dart';
 import '../demo/stars/stars.dart';
@@ -140,6 +141,7 @@ var WIDGETS = {
   'Sky': () => Sky(),
   'Dash': () => DashAnimation(),
   'Stars': () => Stars(),
+  'Outro': () => Outro(),
 };
 
 Widget _square(Widget child) => AspectRatio(


### PR DESCRIPTION
Prevent unnecessary rebuilds (using a `CachingBuilder`) and unnecessary repaints (using a `RepaintBoundary`) of text in the outro.