### PR TITLE
use drawAtlas for more efficient dash painting

### DIFF
--- a/lib/demo/sky/dash_painter.dart
+++ b/lib/demo/sky/dash_painter.dart
@@ -15,75 +15,78 @@ final tailPaint = Paint()..color = '#0E2D7D'.toColor();
 ///
 /// The animation position is determined by [value], which is expected to take
 /// values between 0.0 and 1.0.
-ui.Picture paintDash(double value) {
+ui.Image paintDash(double value) {
   assert(0.0 <= value && value <= 1.0);
   return _frames[(value * _framesPerAnimationCycle).toInt()];
 }
 
 const int _framesPerAnimationCycle = 10;
 
-final List<ui.Picture> _frames = () {
-  final frames = <ui.Picture>[];
+List<ui.Image> _frames;
+
+const dashWidth = 500.0;
+const dashHeight = 500.0;
+const dashSize = Size(dashWidth, dashHeight);
+
+Future<void> initializeDashPainter() async {
+  final frames = <ui.Image>[];
   for (var i = 0; i < _framesPerAnimationCycle; i++) {
-    frames.add(_paintOneFrame(i / _framesPerAnimationCycle));
+    frames.add(await _paintOneFrame(i / _framesPerAnimationCycle).toImage(dashWidth.toInt(), dashHeight.toInt()));
   }
-  return frames;
-}();
+  _frames = frames;
+}
 
 ui.Picture _paintOneFrame(double value) {
-  const width = 1.0;
-  const height = 1.0;
-  const size = Size(width, height);
-  const cullRect = Rect.fromLTRB(0, 0, width, height);
+  const cullRect = Rect.fromLTRB(0, 0, dashWidth, dashHeight);
 
   final recorder = ui.PictureRecorder();
   final canvas = ui.Canvas(recorder, cullRect);
   var feetPaint = Paint()
-    ..strokeWidth = size.width * 0.01
+    ..strokeWidth = dashWidth * 0.01
     ..strokeCap = StrokeCap.round
     ..color = '#725D48'.toColor();
 
   // Left feet
-  var leftFeetStart = Offset(size.width * 0.53, size.height * 0.75);
+  var leftFeetStart = Offset(dashWidth * 0.53, dashHeight * 0.75);
   var leftFeetVec =
-      Offset(size.width * (0.01 + value * 0.02), size.height * 0.08);
+      Offset(dashWidth * (0.01 + value * 0.02), dashHeight * 0.08);
   var leftFeetMiddle = Offset(
       leftFeetStart.dx + leftFeetVec.dx, leftFeetStart.dy + leftFeetVec.dy);
   canvas.drawLine(leftFeetStart, leftFeetMiddle, feetPaint);
   canvas.drawLine(
       leftFeetMiddle,
-      Offset(leftFeetMiddle.dx + size.width * -0.02,
-          leftFeetMiddle.dy + size.height * 0.05),
+      Offset(leftFeetMiddle.dx + dashWidth * -0.02,
+          leftFeetMiddle.dy + dashHeight * 0.05),
       feetPaint);
   canvas.drawLine(
       leftFeetMiddle,
-      Offset(leftFeetMiddle.dx + size.width * 0,
-          leftFeetMiddle.dy + size.height * 0.06),
+      Offset(leftFeetMiddle.dx + dashWidth * 0,
+          leftFeetMiddle.dy + dashHeight * 0.06),
       feetPaint);
   canvas.drawLine(
       leftFeetMiddle,
-      Offset(leftFeetMiddle.dx + size.width * 0.02,
-          leftFeetMiddle.dy + size.height * 0.05),
+      Offset(leftFeetMiddle.dx + dashWidth * 0.02,
+          leftFeetMiddle.dy + dashHeight * 0.05),
       feetPaint);
 
   // Tail
   var tailPath = Path()
-    ..moveTo(size.width * 0.55, size.height * 0.6)
-    ..lineTo(size.width * 0.75, size.height * 0.55)
-    ..quadraticBezierTo(size.width * 0.95, size.height * 0.55, size.width * 0.9,
-        size.height * 0.6)
-    ..quadraticBezierTo(size.width * 0.95, size.height * 0.65, size.width * 0.9,
-        size.height * 0.68)
-    ..quadraticBezierTo(size.width * 0.95, size.height * 0.75, size.width * 0.9,
-        size.height * 0.75)
+    ..moveTo(dashWidth * 0.55, dashHeight * 0.6)
+    ..lineTo(dashWidth * 0.75, dashHeight * 0.55)
+    ..quadraticBezierTo(dashWidth * 0.95, dashHeight * 0.55, dashWidth * 0.9,
+        dashHeight * 0.6)
+    ..quadraticBezierTo(dashWidth * 0.95, dashHeight * 0.65, dashWidth * 0.9,
+        dashHeight * 0.68)
+    ..quadraticBezierTo(dashWidth * 0.95, dashHeight * 0.75, dashWidth * 0.9,
+        dashHeight * 0.75)
     ..close();
   canvas.drawPath(tailPath, tailPaint);
 
   // Body
   var bodyOval = Rect.fromCenter(
-      center: size.center(Offset.zero),
-      width: size.width / (2.2 - 0.03 * value),
-      height: size.height / (2 - 0.03 * value));
+      center: dashSize.center(Offset.zero),
+      width: dashWidth / (2.2 - 0.03 * value),
+      height: dashHeight / (2 - 0.03 * value));
   canvas.drawOval(bodyOval, bodyPaint);
 
   // Breast
@@ -91,150 +94,150 @@ ui.Picture _paintOneFrame(double value) {
   canvas.clipPath(Path()..addOval(bodyOval));
 
   var breastOval = Rect.fromCenter(
-      center: size.center(Offset(-0.07 * size.width, 0.15 * size.height)),
-      width: size.width / 3,
-      height: size.height / 3);
+      center: dashSize.center(Offset(-0.07 * dashWidth, 0.15 * dashHeight)),
+      width: dashWidth / 3,
+      height: dashHeight / 3);
   canvas.drawOval(breastOval, breastPaint);
   canvas.restore();
 
   // Breast color
   canvas.drawOval(
       Rect.fromCenter(
-          center: size.center(Offset(
-            size.width * -0.05,
-            size.height * -0.07,
+          center: dashSize.center(Offset(
+            dashWidth * -0.05,
+            dashHeight * -0.07,
           )),
-          width: size.width / 3.8,
-          height: size.height / 3),
+          width: dashWidth / 3.8,
+          height: dashHeight / 3),
       bodyPaint);
 
   // Eyes Outer
   var leftEyeOval = Rect.fromCenter(
-      center: size.center(Offset(-0.1 * size.width, -0.05 * size.height)),
-      width: size.width / 6,
-      height: size.height / 5);
+      center: dashSize.center(Offset(-0.1 * dashWidth, -0.05 * dashHeight)),
+      width: dashWidth / 6,
+      height: dashHeight / 5);
   canvas.drawOval(leftEyeOval, eyesOuterPaint);
 
   var rightEyeOval = Rect.fromCenter(
-      center: size.center(Offset(0 * size.width, -0.05 * size.height)),
-      width: size.width / 6,
-      height: size.height / 5);
+      center: dashSize.center(Offset(0 * dashWidth, -0.05 * dashHeight)),
+      width: dashWidth / 6,
+      height: dashHeight / 5);
   canvas.drawOval(rightEyeOval, eyesOuterPaint);
 
   // Eyes Inner
   var leftEyeInnerOval = Rect.fromCenter(
-      center: size.center(Offset(-0.1 * size.width, -0.05 * size.height)),
-      width: size.width / 12,
-      height: size.height / 8);
+      center: dashSize.center(Offset(-0.1 * dashWidth, -0.05 * dashHeight)),
+      width: dashWidth / 12,
+      height: dashHeight / 8);
   canvas.drawOval(leftEyeInnerOval, eyesInnerPaint);
 
   var rightEyeInnerOval = Rect.fromCenter(
-      center: size.center(Offset(0 * size.width, -0.05 * size.height)),
-      width: size.width / 12,
-      height: size.height / 8);
+      center: dashSize.center(Offset(0 * dashWidth, -0.05 * dashHeight)),
+      width: dashWidth / 12,
+      height: dashHeight / 8);
   canvas.drawOval(rightEyeInnerOval, eyesInnerPaint);
 
   // Eyes Reflection 1
   var leftEyeReflection1Oval = Rect.fromCenter(
-      center: size.center(Offset(-0.11 * size.width, -0.03 * size.height)),
-      width: size.width / 50,
-      height: size.height / 50);
+      center: dashSize.center(Offset(-0.11 * dashWidth, -0.03 * dashHeight)),
+      width: dashWidth / 50,
+      height: dashHeight / 50);
   canvas.drawOval(leftEyeReflection1Oval, eyesReflectionPaint);
 
   var rightEyeReflection1Oval = Rect.fromCenter(
-      center: size.center(Offset(-0.01 * size.width, -0.03 * size.height)),
-      width: size.width / 50,
-      height: size.height / 50);
+      center: dashSize.center(Offset(-0.01 * dashWidth, -0.03 * dashHeight)),
+      width: dashWidth / 50,
+      height: dashHeight / 50);
   canvas.drawOval(rightEyeReflection1Oval, eyesReflectionPaint);
 
   // Eyes Reflection 2
   var leftEyeReflection2Oval = Rect.fromCenter(
-      center: size.center(Offset(-0.09 * size.width, -0.07 * size.height)),
-      width: size.width / 80,
-      height: size.height / 80);
+      center: dashSize.center(Offset(-0.09 * dashWidth, -0.07 * dashHeight)),
+      width: dashWidth / 80,
+      height: dashHeight / 80);
   canvas.drawOval(leftEyeReflection2Oval, eyesReflectionPaint);
 
   var rightEyeReflection2Oval = Rect.fromCenter(
-      center: size.center(Offset(0.01 * size.width, -0.07 * size.height)),
-      width: size.width / 80,
-      height: size.height / 80);
+      center: dashSize.center(Offset(0.01 * dashWidth, -0.07 * dashHeight)),
+      width: dashWidth / 80,
+      height: dashHeight / 80);
   canvas.drawOval(rightEyeReflection2Oval, eyesReflectionPaint);
 
   // Nose
-  var noseStart = Offset(size.width * 0.44, size.height * 0.5);
+  var noseStart = Offset(dashWidth * 0.44, dashHeight * 0.5);
   var nosePath = Path()
     ..moveTo(noseStart.dx, noseStart.dy)
-    ..lineTo(noseStart.dx - size.width * 0.4, noseStart.dy + size.height * 0.03)
-    ..lineTo(noseStart.dx, noseStart.dy + 0.07 * size.height)
+    ..lineTo(noseStart.dx - dashWidth * 0.4, noseStart.dy + dashHeight * 0.03)
+    ..lineTo(noseStart.dx, noseStart.dy + 0.07 * dashHeight)
     ..quadraticBezierTo(
-      noseStart.dx + size.width * 0.05,
-      noseStart.dy + size.height * 0.03,
+      noseStart.dx + dashWidth * 0.05,
+      noseStart.dy + dashHeight * 0.03,
       noseStart.dx,
       noseStart.dy,
     );
   canvas.drawPath(nosePath, nosePaint);
 
   // Right feet
-  var rightFeetStart = Offset(size.width * 0.62, size.height * 0.70);
+  var rightFeetStart = Offset(dashWidth * 0.62, dashHeight * 0.70);
   var rightFeetVec =
-      Offset(size.width * (0.02 + (value) * 0.015), size.height * 0.13);
+      Offset(dashWidth * (0.02 + (value) * 0.015), dashHeight * 0.13);
   var rightFeetMiddle = Offset(
       rightFeetStart.dx + rightFeetVec.dx, rightFeetStart.dy + rightFeetVec.dy);
   canvas.drawLine(rightFeetStart, rightFeetMiddle, feetPaint);
   canvas.drawLine(
       rightFeetMiddle,
-      Offset(rightFeetMiddle.dx + size.width * -0.02,
-          rightFeetMiddle.dy + size.height * 0.06),
+      Offset(rightFeetMiddle.dx + dashWidth * -0.02,
+          rightFeetMiddle.dy + dashHeight * 0.06),
       feetPaint);
   canvas.drawLine(
       rightFeetMiddle,
-      Offset(rightFeetMiddle.dx + size.width * 0,
-          rightFeetMiddle.dy + size.height * 0.07),
+      Offset(rightFeetMiddle.dx + dashWidth * 0,
+          rightFeetMiddle.dy + dashHeight * 0.07),
       feetPaint);
   canvas.drawLine(
       rightFeetMiddle,
-      Offset(rightFeetMiddle.dx + size.width * 0.02,
-          rightFeetMiddle.dy + size.height * 0.06),
+      Offset(rightFeetMiddle.dx + dashWidth * 0.02,
+          rightFeetMiddle.dy + dashHeight * 0.06),
       feetPaint);
 
   // Hair
   canvas.save();
   var hairClipPath = Path()
-    ..moveTo(size.width * 0.41, size.height * 0.35)
-    ..quadraticBezierTo(size.width * 0.5, size.height * 0.2, size.width * 0.6,
-        size.height * 0.3)
-    ..lineTo(size.width, 0)
+    ..moveTo(dashWidth * 0.41, dashHeight * 0.35)
+    ..quadraticBezierTo(dashWidth * 0.5, dashHeight * 0.2, dashWidth * 0.6,
+        dashHeight * 0.3)
+    ..lineTo(dashWidth, 0)
     ..lineTo(0, 0)
     ..close();
   canvas.clipPath(hairClipPath);
 
   var hair1Oval = Rect.fromCenter(
-      center: size.center(Offset(size.width * -0.05, size.height * -0.22)),
-      width: size.width / 15,
-      height: size.height / 15);
+      center: dashSize.center(Offset(dashWidth * -0.05, dashHeight * -0.22)),
+      width: dashWidth / 15,
+      height: dashHeight / 15);
   canvas.drawOval(hair1Oval, eyesOuterPaint);
 
   var hair2Oval = Rect.fromCenter(
-      center: size.center(Offset(size.width * -0.01, size.height * -0.23)),
-      width: size.width / 13,
-      height: size.height / 13);
+      center: dashSize.center(Offset(dashWidth * -0.01, dashHeight * -0.23)),
+      width: dashWidth / 13,
+      height: dashHeight / 13);
   canvas.drawOval(hair2Oval, eyesOuterPaint);
 
   var hair3Oval = Rect.fromCenter(
-      center: size.center(Offset(size.width * 0.02, size.height * -0.23)),
-      width: size.width / 15,
-      height: size.height / 15);
+      center: dashSize.center(Offset(dashWidth * 0.02, dashHeight * -0.23)),
+      width: dashWidth / 15,
+      height: dashHeight / 15);
   canvas.drawOval(hair3Oval, eyesOuterPaint);
   canvas.restore();
 
   // Wing
-  var rightWing1 = Offset(size.width * 0.62, size.height * 0.52);
-  var rightWing2 = Offset(size.width * 0.9, size.height * (0.6 - 0.1 * value));
+  var rightWing1 = Offset(dashWidth * 0.62, dashHeight * 0.52);
+  var rightWing2 = Offset(dashWidth * 0.9, dashHeight * (0.6 - 0.1 * value));
   var rightWingC1 = Offset(
-    (rightWing1.dx + rightWing2.dx) / 2 + size.width * 0.2,
-    (rightWing1.dy + rightWing2.dy) / 2 - size.height * 0.2,
+    (rightWing1.dx + rightWing2.dx) / 2 + dashWidth * 0.2,
+    (rightWing1.dy + rightWing2.dy) / 2 - dashHeight * 0.2,
   );
-  var rightWingC2 = Offset(rightWingC1.dx, rightWingC1.dy + size.height * 0.45);
+  var rightWingC2 = Offset(rightWingC1.dx, rightWingC1.dy + dashHeight * 0.45);
   var rightWingPath = Path()
     ..moveTo(rightWing1.dx, rightWing1.dy)
     ..quadraticBezierTo(
@@ -245,11 +248,11 @@ ui.Picture _paintOneFrame(double value) {
 
   canvas.save();
   var wingClipPath = Path()
-    ..moveTo(size.width * 0.68, size.height * 0.48)
-    ..quadraticBezierTo(size.width * 0.63, size.height * 0.53, size.width * 0.7,
-        size.height * 0.6)
-    ..lineTo(size.width, size.height)
-    ..lineTo(size.width, 0)
+    ..moveTo(dashWidth * 0.68, dashHeight * 0.48)
+    ..quadraticBezierTo(dashWidth * 0.63, dashHeight * 0.53, dashWidth * 0.7,
+        dashHeight * 0.6)
+    ..lineTo(dashWidth, dashHeight)
+    ..lineTo(dashWidth, 0)
     ..close();
   canvas.clipPath(wingClipPath);
   canvas.drawPath(rightWingPath, eyesOuterPaint);

--- a/lib/demo/sky/sky.dart
+++ b/lib/demo/sky/sky.dart
@@ -23,7 +23,7 @@ class Sky extends StatelessWidget {
               children: [
                 Positioned.fill(child: SkyGradient()),
                 Positioned.fill(child: CloudsPlasma()),
-                if (otherDashes > 0) ..._otherDashes(otherDashes, constraints),
+                if (otherDashes > 0) Positioned.fill(child: OtherDashes(otherDashes)),
                 Positioned(
                   left: value.get<double>(_P.left1) * constraints.maxWidth,
                   top: value.get<double>(_P.top1) * constraints.maxHeight,
@@ -40,30 +40,21 @@ class Sky extends StatelessWidget {
           });
     });
   }
+}
 
-  List<Positioned> _otherDashes(double value, BoxConstraints constraints) {
-    var random = Random(18);
-    var randomAngle = Random(16);
+class OtherDashes extends StatelessWidget {
+  OtherDashes(this.otherDashes);
 
-    var dashes = <Positioned>[];
+  final double otherDashes;
 
-    0.until(20).forEach((n) {
-      var left = 0.0 + 1.0 * random.nextDouble() + (1 - value) * 0.3;
-      var top = 2.4 * (1 - value) - 1.2 + random.nextDouble();
-      var size = 0.14 + 0.08 * random.nextDouble() - value * 0.1;
-
-      dashes.add(Positioned(
-        left: left * constraints.maxWidth,
-        top: top * constraints.maxHeight,
-        width: size * constraints.maxWidth,
-        height: size * constraints.maxWidth,
-        child: Transform.rotate(
-            angle: 0.3 + 0.2 * randomAngle.nextDouble(),
-            child: DashAnimation()),
-      ));
-    });
-
-    return dashes;
+  @override
+  Widget build(BuildContext context) {
+    return MirrorAnimation<double>(
+        tween: 0.0.tweenTo(1.0),
+        duration: 300.milliseconds,
+        builder: (context, child, value) {
+          return CustomPaint(painter: MultiDashPainter(otherDashes, value));
+        });
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,10 @@ import 'package:url_strategy/url_strategy.dart';
 import 'demo/intro/intro.dart';
 import 'routed_app.dart';
 
-void main() {
+import 'demo/sky/dash_painter.dart';
+
+void main() async {
+  await initializeDashPainter();
   setPathUrlStrategy();
 
   if (kReleaseMode || kProfileMode) {


### PR DESCRIPTION
Change the precomputed Dash animation from `Picture` to `Image` and use `drawRawAtlas` instead of `drawPicture`. This speeds up the Sky demo.